### PR TITLE
Improve acknowledgement parsing and success checking

### DIFF
--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -1,5 +1,8 @@
 use crate::{routing::Context, DenomToAssetId};
-use alloc::{format, string::ToString};
+use alloc::{
+	format,
+	string::{String, ToString},
+};
 use core::{fmt::Debug, marker::PhantomData, str::FromStr};
 use ibc::{
 	applications::transfer::{
@@ -361,7 +364,7 @@ where
 					"Failed to decode acknowledgement {e:?}"
 				))
 			})
-			.and_then(|x| {
+			.and_then(|x: String| {
 				Ics20Ack::from_str(&x).map_err(|e| {
 					Ics04Error::implementation_specific(format!(
 						"Failed to decode acknowledgement {e:?}"

--- a/ibc/modules/src/applications/transfer/acknowledgement.rs
+++ b/ibc/modules/src/applications/transfer/acknowledgement.rs
@@ -43,7 +43,7 @@ impl Acknowledgement {
 	}
 
 	pub fn is_successful(&self) -> bool {
-		matches!(self, Self::Result(s) if s == ACK_SUCCESS_B64)
+		!matches!(self, Self::Error(s))
 	}
 
 	pub fn into_result(self) -> Result<String, String> {


### PR DESCRIPTION
Instead of checking equality with a successful acknowledgement string, it now utilizes the `is_successful` method directly on the parsed acknowledgement