### PR TITLE
Fix process-compose down usage and lints error.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,4 +120,3 @@ jobs:
           RUST_BACKTRACE=full METRICS_PORT=39998 ./wait-for-parachains-network.sh 
           # SKIP_WASM_BUILD=1 cargo +${{ env.RUST_VERSION }} nextest run --locked --release --workspace --exclude ibc-derive --exclude hyperspace-testsuite
           RUST_BACKTRACE=full cargo +${{ env.RUST_VERSION }} test -p hyperspace-testsuite --locked
-          process-compose down -f process-compose.yml

--- a/hyperspace/core/src/substrate/default.rs
+++ b/hyperspace/core/src/substrate/default.rs
@@ -173,7 +173,10 @@ impl light_client_common::config::Config for DefaultConfig {
 
 	async fn custom_extrinsic_params(
 		client: &OnlineClient<Self>,
-	) -> Result<<Self::ExtrinsicParams as ExtrinsicParams<Self::Index, Self::Hash>>::OtherParams, Error> {
+	) -> Result<
+		<Self::ExtrinsicParams as ExtrinsicParams<Self::Index, Self::Hash>>::OtherParams,
+		Error,
+	> {
 		let params =
 			ParachainExtrinsicsParamsBuilder::new().era(Era::Immortal, client.genesis_hash());
 		Ok(params)

--- a/hyperspace/core/src/substrate/mod.rs
+++ b/hyperspace/core/src/substrate/mod.rs
@@ -6,11 +6,10 @@ pub mod default;
 // pub mod picasso_rococo;
 // pub mod composable;
 
-
-pub use default::DefaultConfig;
-pub use default::DefaultConfig as ComposableConfig;
-pub use default::DefaultConfig as PicassoKusamaConfig;
-pub use default::DefaultConfig as PicassoRococoConfig;
+pub use default::{
+	DefaultConfig, DefaultConfig as ComposableConfig, DefaultConfig as PicassoKusamaConfig,
+	DefaultConfig as PicassoRococoConfig,
+};
 // pub use composable::ComposableConfig;
 // pub use picasso_kusama::PicassoKusamaConfig;
 // pub use picasso_rococo::PicassoRococoConfig;

--- a/hyperspace/parachain/src/chain.rs
+++ b/hyperspace/parachain/src/chain.rs
@@ -304,8 +304,9 @@ where
 		let extrinsic_opaque =
 			block.block.extrinsics.get(transaction_index).expect("Extrinsic not found");
 
-		let unchecked_extrinsic = UncheckedExtrinsic::<T>::decode(&mut &*extrinsic_opaque.0.encode())
-			.map_err(|e| Error::from(format!("Extrinsic decode error: {}", e)))?;
+		let unchecked_extrinsic =
+			UncheckedExtrinsic::<T>::decode(&mut &*extrinsic_opaque.0.encode())
+				.map_err(|e| Error::from(format!("Extrinsic decode error: {}", e)))?;
 
 		let messages = unchecked_extrinsic
 			.function


### PR DESCRIPTION
process-compose down does not exist. so removed this command.

fix rust linters with fix lint by cargo +nightly fmt --all --