### PR TITLE
Change timeout height from 100 blocks to  to 20 blocks

### DIFF
--- a/hyperspace/testsuite/src/lib.rs
+++ b/hyperspace/testsuite/src/lib.rs
@@ -261,7 +261,7 @@ async fn send_packet_and_assert_height_timeout<A, B>(
 		chain_b,
 		asset_a,
 		channel_id,
-		Some(Timeout::Offset { timestamp: Some(120 * 60), height: Some(100) }),
+		Some(Timeout::Offset { timestamp: Some(120 * 60), height: Some(20) }),
 	)
 	.await;
 


### PR DESCRIPTION
The fix for timeout height:
problem: 
- old timeout height in test is 100 blocks.
- test waits 1200 secs for the block number : current_block + 100
- block time is 12 sec. so the timeout height should happen in 1200 sec.
- the test failed in timeout height happed in 1201 sec because of some network delay(depends on zombienet configuration)