### PR TITLE
Ci optimise cloud costs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,9 @@ jobs:
       cancel-in-progress: true
     container:
       image: paritytech/ci-unified:bullseye-1.71.0-v20230727
-    runs-on: ubuntu-latest-m
+    runs-on:
+      - self-hosted
+      - x64-tiny
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,19 +3,26 @@ name: Cargo Check
 on:
   pull_request:
     branches:
-      - '*'
+      - 'master'
+      - 'develop'
+      - 'release*'
   push:
     branches:
-      - master
+      - 'master'
+      - 'develop'
+      - 'release*'
 
 
 jobs:
   checker:
+
     concurrency:
       group: lint-${{ github.ref }}
       cancel-in-progress: true
+
     container:
       image: paritytech/ci-unified:bullseye-1.71.0-v20230727
+
     runs-on:
       - self-hosted
       - x64-tiny

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
       cancel-in-progress: true
     container:
       image: paritytech/ci-unified:bullseye-1.71.0-v20230727
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,9 +16,7 @@ jobs:
       cancel-in-progress: true
     container:
       image: paritytech/ci-unified:bullseye-1.71.0-v20230727
-    runs-on:
-      - self-hosted
-      - x64-monster
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,6 @@ on:
       - 'develop'
       - 'release*'
 
-
 jobs:
   checker:
 
@@ -26,6 +25,7 @@ jobs:
     runs-on:
       - self-hosted
       - x64-tiny
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/hyperspace-docker-image.yml
+++ b/.github/workflows/hyperspace-docker-image.yml
@@ -3,7 +3,9 @@ name: "Build and publish Hyperspace Docker image"
 on:
   push:
     branches:
-      - '*'
+      - 'master'
+      - 'develop'
+      - 'release*'
     tags:
       - 'v*'
 

--- a/.github/workflows/hyperspace-docker-image.yml
+++ b/.github/workflows/hyperspace-docker-image.yml
@@ -18,9 +18,7 @@ jobs:
 
     name: Build & push docker image
     
-    runs-on:
-      - self-hosted
-      - x64-monster
+    runs-on: ubuntu-latest
     
     concurrency:
       group: hyperspace-docker-image-${{ github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,14 @@ name: Lint
 on:
   pull_request:
     branches:
-      - '*'
+      - 'master'
+      - 'develop'
+      - 'release*'
   push:
     branches:
-      - master
+      - 'master'
+      - 'develop'
+      - 'release*'
 
 jobs:
   linters:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,7 @@ jobs:
       cancel-in-progress: true
     container:
       image: paritytech/ci-unified:bullseye-1.71.0-v20230727
-    runs-on:
-      - self-hosted
-      - x64-monster
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/parachain-node-docker-image.yml
+++ b/.github/workflows/parachain-node-docker-image.yml
@@ -13,9 +13,7 @@ on:
 
 jobs:
   build-and-publish:
-    runs-on:
-      - self-hosted
-      - x64-monster
+    runs-on: ubuntu-latest
     concurrency:
       group: parachain-node-docker-image-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,9 @@
 name: Test
 
 on:
-  pull_request:
-    branches:
-      - 'master'
-      - 'develop'
-      - 'release*'
   push:
     branches:
       - 'master'
-      - 'develop'
       - 'release*'
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         - /home/ghr/_work/_temp:/home/ghr/_work/_temp
     runs-on:
       - self-hosted
-      - x64-tiny
+      - x64-monster
     timeout-minutes: 300
     steps:
       - name: Install git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,9 @@ jobs:
         RUST_LOG: hyperspace=trace,hyperspace_parachain=trace
       volumes:
         - /home/ghr/_work/_temp:/home/ghr/_work/_temp
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - x64-tiny
     timeout-minutes: 300
     steps:
       - name: Install git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,14 @@ name: Test
 on:
   pull_request:
     branches:
-      - '*'
+      - 'master'
+      - 'develop'
+      - 'release*'
   push:
     branches:
-      - master
+      - 'master'
+      - 'develop'
+      - 'release*'
 
 env:
   DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,7 @@ jobs:
         RUST_LOG: hyperspace=trace,hyperspace_parachain=trace
       volumes:
         - /home/ghr/_work/_temp:/home/ghr/_work/_temp
-    runs-on:
-      - self-hosted
-      - x64-monster
+    runs-on: ubuntu-latest
     timeout-minutes: 300
     steps:
       - name: Install git


### PR DESCRIPTION
Instead of using `e2-standard-32` in gcp, we can use Github runners.