### PR TITLE
Weaken GRANDPA proof validation

### DIFF
--- a/algorithms/grandpa/primitives/src/justification.rs
+++ b/algorithms/grandpa/primitives/src/justification.rs
@@ -77,14 +77,7 @@ where
 		let ancestry_chain = AncestryChain::<H>::new(&self.votes_ancestries);
 
 		match finality_grandpa::validate_commit(&self.commit, voters, &ancestry_chain) {
-			Ok(ref result) if result.is_valid() => {
-				if result.num_duplicated_precommits() > 0 ||
-					result.num_invalid_voters() > 0 ||
-					result.num_equivocations() > 0
-				{
-					Err(anyhow!("Invalid commit, found one of `duplicate precommits`, `invalid voters`, or `equivocations` {result:?}"))?
-				}
-			},
+			Ok(ref result) if result.is_valid() => (), // no additional checks required
 			err => {
 				let result = err.map_err(|_| {
 					anyhow!("[verify_with_voter_set] Invalid ancestry while validating commit!")


### PR DESCRIPTION
`verify_with_voter_set` function is performing additional validation that go beyond the [standard implementation](https://raw.githubusercontent.com/w3f/consensus/master/pdf/grandpa.pdf) (section 2.3), possibly leading to proofs not being accepted while valid.

Instead, we need to accept all finality justifications where is_valid is true. The equivocations or other misbehaviors detected in the justifications must be handled too but not should not reject the proof.