### PR TITLE
Update token supply from L1 to Rollup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
  "mpl-token-metadata",
  "solana-program",
  "spl-associated-token-account",
- "spl-token",
+ "spl-token 4.0.0",
  "spl-token-2022 0.9.0",
 ]
 
@@ -5662,6 +5662,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-trie",
  "solana-write-account",
+ "spl-token 3.5.0",
  "stdx",
  "tendermint 0.33.2",
  "tendermint 0.34.1",
@@ -8851,6 +8852,15 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
@@ -8865,6 +8875,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
  "num_enum_derive 0.7.2",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -15280,7 +15302,7 @@ dependencies = [
  "serde_json",
  "solana-config-program",
  "solana-sdk",
- "spl-token",
+ "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
@@ -15454,7 +15476,7 @@ dependencies = [
  "solana-signature-verifier",
  "solana-trie",
  "spl-associated-token-account",
- "spl-token",
+ "spl-token 4.0.0",
  "stdx",
  "strum 0.25.0",
  "tendermint 0.34.1",
@@ -15955,7 +15977,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account",
  "spl-memo",
- "spl-token",
+ "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "thiserror",
 ]
@@ -17242,7 +17264,7 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
- "spl-token",
+ "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "thiserror",
 ]
@@ -17359,6 +17381,20 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
+version = "3.5.0"
+source = "git+https://github.com/ComposableFi/solana-program-library.git?branch=mantis#294feb78bf6e8aea9598c692485a41b529012b84"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.3.3",
+ "num-traits",
+ "num_enum 0.5.11",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08459ba1b8f7c1020b4582c4edf0f5c7511a5e099a7a97570c9698d4f2337060"
@@ -17387,7 +17423,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
- "spl-token",
+ "spl-token 4.0.0",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface 0.3.0",
  "spl-type-length-value",
@@ -17410,7 +17446,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
- "spl-token",
+ "spl-token 4.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface 0.4.1",

--- a/hyperspace/rollup/Cargo.toml
+++ b/hyperspace/rollup/Cargo.toml
@@ -16,11 +16,13 @@ log = "0.4.17"
 hex = "0.4.3"
 tokio = { version = "1.32.0", features = ["macros", "sync"] }
 rs_merkle = "1.2.0"
-codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", features = [
+    "derive",
+] }
 serde_json = "1.0.74"
-derive_more = { version = "0.99", features = ["from"]  }
-serde = {version="1.0.137", features = ["derive"]}
-tokio-stream = { version = "0.1.14", features = ["sync"]}
+derive_more = { version = "0.99", features = ["from"] }
+serde = { version = "1.0.137", features = ["derive"] }
+tokio-stream = { version = "0.1.14", features = ["sync"] }
 thiserror = "1.0.31"
 itertools = "0.10.3"
 prost = { version = "0.11" }
@@ -35,7 +37,7 @@ ripemd = "0.1.3"
 digest = "0.10.6"
 quick_cache = "0.3.0"
 rand = "0.8.5"
-anchor-client = {version = "0.29.0", features = ["async"] }
+anchor-client = { version = "0.29.0", features = ["async"] }
 anchor-lang = "0.29.0"
 anchor-spl = "0.29.0"
 solana-transaction-status = "=1.17.31"
@@ -54,8 +56,14 @@ bs58 = { version = "0.5.0", features = ["alloc"] }
 bincode = { version = "1.3.3" }
 
 # New IBC
-ibc-new-primitives = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false, features = ["borsh", "serde"] , package="ibc-primitives" }
-ibc-core-host-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false, features = ["borsh", "serde"]}
+ibc-new-primitives = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false, features = [
+    "borsh",
+    "serde",
+], package = "ibc-primitives" }
+ibc-core-host-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false, features = [
+    "borsh",
+    "serde",
+] }
 ibc-core-handler-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
 ibc-core-client-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
 ibc-core-connection-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
@@ -63,41 +71,53 @@ ibc-core-channel-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be
 ibc-app-transfer-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
 ibc-core-commitment-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
 ibc-client-tendermint-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-client-wasm-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false}
+ibc-client-wasm-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
 # ibc-testkit = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-proto-new = { version = "0.41.0", default-features = false, package="ibc-proto" }
+ibc-proto-new = { version = "0.41.0", default-features = false, package = "ibc-proto" }
 
 ics23 = { version = "0.11.1" }
 
 
-
 # Old IBC
 ibc = { path = "../../ibc/modules", features = [] }
-ibc-proto = { path = "../../ibc/proto", package="ibc-proto" }
+ibc-proto = { path = "../../ibc/proto", package = "ibc-proto" }
 ibc-primitives = { path = "../../contracts/pallet-ibc/primitives" }
-ics07-tendermint = { path = "../../light-clients/ics07-tendermint", features = ["dummy"] }
+ics07-tendermint = { path = "../../light-clients/ics07-tendermint", features = [
+    "dummy",
+] }
 ics08-wasm = { path = "../../light-clients/ics08-wasm" }
 ibc-rpc = { path = "../../contracts/pallet-ibc/rpc" }
-pallet-ibc = { path = "../../contracts/pallet-ibc", features = ["testing"]}
+pallet-ibc = { path = "../../contracts/pallet-ibc", features = ["testing"] }
 
 # Trie
 lib = { git = "https://github.com/ComposableFi/emulated-light-client/" }
 memory = { git = "https://github.com/ComposableFi/emulated-light-client/" }
-sealable-trie = { git = "https://github.com/ComposableFi/emulated-light-client/" ,features = ["borsh"] }
+sealable-trie = { git = "https://github.com/ComposableFi/emulated-light-client/", features = [
+    "borsh",
+] }
 stdx = { git = "https://github.com/ComposableFi/emulated-light-client/" }
 solana-trie = { git = "https://github.com/ComposableFi/emulated-light-client/" }
-trie-ids = { git = "https://github.com/ComposableFi/emulated-light-client/" ,features = ["borsh"] }
+trie-ids = { git = "https://github.com/ComposableFi/emulated-light-client/", features = [
+    "borsh",
+] }
 cf-guest = { path = "../../light-clients/cf-guest", default-features = false }
-cf-guest-og = { git = "https://github.com/ComposableFi/emulated-light-client/" ,package = "cf-guest" }
-guestchain = { git = "https://github.com/ComposableFi/emulated-light-client/" ,default-features = false }
+cf-guest-og = { git = "https://github.com/ComposableFi/emulated-light-client/", package = "cf-guest" }
+guestchain = { git = "https://github.com/ComposableFi/emulated-light-client/", default-features = false }
 
-cf-solana-og = { git = "https://github.com/ComposableFi/emulated-light-client/", package = "cf-solana", features = ["serde"] }
+cf-solana-og = { git = "https://github.com/ComposableFi/emulated-light-client/", package = "cf-solana", features = [
+    "serde",
+] }
 cf-solana = { path = "../../light-clients/cf-solana", default-features = false }
 
 #Contract
-solana-ibc = { git = "https://github.com/ComposableFi/emulated-light-client/", features = ["no-entrypoint", "witness"]}
-solana-write-account = { git = "https://github.com/ComposableFi/emulated-light-client/" ,features = ["library"] }
+solana-ibc = { git = "https://github.com/ComposableFi/emulated-light-client/", features = [
+    "no-entrypoint",
+] }
+solana-write-account = { git = "https://github.com/ComposableFi/emulated-light-client/", features = [
+    "library",
+] }
 solana-signature-verifier = { git = "https://github.com/ComposableFi/emulated-light-client/" }
+spl-token = { git = "https://github.com/ComposableFi/solana-program-library.git", branch = "mantis" }
 
 tracing = "0.1.36"
 
@@ -115,12 +135,10 @@ tendermint-light-client = { git = "https://github.com/informalsystems/tendermint
     "rpc-client",
     "secp256k1",
     "unstable",
-#    "testing"
+    #    "testing"
 ] }
 tendermint-light-client-verifier = { git = "https://github.com/informalsystems/tendermint-rs", rev = "4d81b67c28510db7d2d99ed62ebfa9fdf0e02141", default-features = false }
 tendermint-light-client-verifier_new = { git = "https://github.com/mina86/tendermint-rs", rev = "45fbd500d731effb95a98257630feb46f6c41d06", default-features = false, package = "tendermint-light-client-verifier" }
 
 [features]
-testing = [
-    "primitives/testing"
-]
+testing = ["primitives/testing"]

--- a/hyperspace/rollup/src/client.rs
+++ b/hyperspace/rollup/src/client.rs
@@ -122,6 +122,7 @@ pub struct RollupClient {
 	pub last_searched_sig_for_send_packets: Arc<tokio::sync::Mutex<String>>,
 	pub last_searched_sig_for_recv_packets: Arc<tokio::sync::Mutex<String>>,
 	pub last_supply_update_time: Arc<tokio::sync::Mutex<std::time::Instant>>,
+	pub supply_update_time_in_sec: u64,
 	/// Reference to commitment
 	pub commitment_prefix: CommitmentPrefix,
 	/// Channels cleared for packet relay
@@ -178,6 +179,7 @@ pub struct RollupClientConfig {
 	pub signature_verifier_program_id: String,
 	pub trie_db_path: String,
 	pub transaction_sender: String,
+	pub supply_update_time_in_sec: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -386,6 +388,13 @@ impl RollupClient {
 			"RPC" => TransactionSender::RPC,
 			_ => panic!("Invalid param transaction sender: Expected JITO/RPC"),
 		};
+
+		let supply_update_time_in_sec = if config.supply_update_time_in_sec > 0 {
+			config.supply_update_time_in_sec
+		} else {
+			24 * 60 * 60
+		};
+
 		Ok(Self {
 			name: config.name,
 			rpc_url: config.rpc_url.to_string(),
@@ -418,6 +427,7 @@ impl RollupClient {
 				tokio::sync::Mutex::new(String::default()),
 			),
 			last_supply_update_time: Arc::new(tokio::sync::Mutex::new(std::time::Instant::now())),
+			supply_update_time_in_sec,
 			commitment_prefix: CommitmentPrefix::try_from(config.commitment_prefix).unwrap(),
 			channel_whitelist: Arc::new(Mutex::new(config.channel_whitelist.into_iter().collect())),
 			trie_db_path: config.trie_db_path,
@@ -1319,4 +1329,3 @@ pub struct PrivateStorageWithWitness {
 
 	pub local_consensus_state: std::collections::VecDeque<(u64, u64, CryptoHash)>,
 }
-

--- a/hyperspace/rollup/src/client.rs
+++ b/hyperspace/rollup/src/client.rs
@@ -122,7 +122,7 @@ pub struct RollupClient {
 	pub last_searched_sig_for_send_packets: Arc<tokio::sync::Mutex<String>>,
 	pub last_searched_sig_for_recv_packets: Arc<tokio::sync::Mutex<String>>,
 	pub last_supply_update_time: Arc<tokio::sync::Mutex<std::time::Instant>>,
-	pub supply_update_time_in_sec: u64,
+	pub supply_update_period_in_sec: u64,
 	/// Reference to commitment
 	pub commitment_prefix: CommitmentPrefix,
 	/// Channels cleared for packet relay
@@ -179,7 +179,9 @@ pub struct RollupClientConfig {
 	pub signature_verifier_program_id: String,
 	pub trie_db_path: String,
 	pub transaction_sender: String,
-	pub supply_update_time_in_sec: u64,
+
+	#[serde(default)]
+	pub supply_update_period_in_sec: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -389,8 +391,8 @@ impl RollupClient {
 			_ => panic!("Invalid param transaction sender: Expected JITO/RPC"),
 		};
 
-		let supply_update_time_in_sec = if config.supply_update_time_in_sec > 0 {
-			config.supply_update_time_in_sec
+		let supply_update_period_in_sec = if config.supply_update_period_in_sec > 0 {
+			config.supply_update_period_in_sec
 		} else {
 			24 * 60 * 60
 		};
@@ -427,7 +429,7 @@ impl RollupClient {
 				tokio::sync::Mutex::new(String::default()),
 			),
 			last_supply_update_time: Arc::new(tokio::sync::Mutex::new(std::time::Instant::now())),
-			supply_update_time_in_sec,
+			supply_update_period_in_sec,
 			commitment_prefix: CommitmentPrefix::try_from(config.commitment_prefix).unwrap(),
 			channel_whitelist: Arc::new(Mutex::new(config.channel_whitelist.into_iter().collect())),
 			trie_db_path: config.trie_db_path,

--- a/hyperspace/rollup/src/lib.rs
+++ b/hyperspace/rollup/src/lib.rs
@@ -2050,7 +2050,7 @@ impl Chain for RollupClient {
 
 			let now = Instant::now();
 
-			if (now - *last).as_secs() > 24 * 60 * 60 {
+			if (now - *last).as_secs() > self.supply_update_time_in_sec {
 				*last = now;
 
 				let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(300_000);

--- a/hyperspace/rollup/src/lib.rs
+++ b/hyperspace/rollup/src/lib.rs
@@ -41,6 +41,7 @@ use tendermint::{Hash, Time};
 use tendermint_proto::Protobuf;
 use tokio::{
 	sync::mpsc::unbounded_channel,
+	sync::Mutex,
 	task::{spawn_blocking, JoinSet},
 };
 
@@ -2042,6 +2043,42 @@ impl Chain for RollupClient {
 			// 	println!("  Signature {:?}", sig);
 			// 	signature = sig.unwrap().to_string();
 			// }
+		}
+
+		{
+			let mut last = self.last_supply_update_time.lock().await;
+
+			let now = Instant::now();
+
+			if (now - *last).as_secs() > 24 * 60 * 60 {
+				*last = now;
+
+				let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(300_000);
+
+				let mantis_token_supply_on_l1 = self
+					.rpc_l1_client()
+					.get_token_supply(&self.solana_token_mint_pubkey)
+					.await
+					.unwrap()
+					.amount
+					.parse::<u64>()
+					.unwrap();
+
+				let ix = spl_token::instruction::update_l1_token_supply(
+					&self.solana_token_program_id,
+					&self.solana_token_mint_pubkey,
+					&[&authority.pubkey()],
+					mantis_token_supply_on_l1,
+				)
+				.unwrap();
+
+				let update_mantis_supply_ix = vec![Transaction::new_with_payer(
+					&[compute_budget_ix.clone(), ix],
+					Some(&authority.pubkey()),
+				)];
+
+				all_transactions.push(update_mantis_supply_ix);
+			}
 		}
 
 		let total_transactions_length = all_transactions.iter().fold(0, |acc, tx| acc + tx.len());

--- a/hyperspace/rollup/src/lib.rs
+++ b/hyperspace/rollup/src/lib.rs
@@ -2050,7 +2050,7 @@ impl Chain for RollupClient {
 
 			let now = Instant::now();
 
-			if (now - *last).as_secs() > self.supply_update_time_in_sec {
+			if (now - *last).as_secs() > self.supply_update_period_in_sec {
 				*last = now;
 
 				let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(300_000);

--- a/hyperspace/solana/Cargo.toml
+++ b/hyperspace/solana/Cargo.toml
@@ -16,11 +16,13 @@ log = "0.4.17"
 hex = "0.4.3"
 tokio = { version = "1.32.0", features = ["macros", "sync"] }
 rs_merkle = "1.2.0"
-codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", features = [
+    "derive",
+] }
 serde_json = "1.0.74"
-derive_more = { version = "0.99", features = ["from"]  }
-serde = {version="1.0.137", features = ["derive"]}
-tokio-stream = { version = "0.1.14", features = ["sync"]}
+derive_more = { version = "0.99", features = ["from"] }
+serde = { version = "1.0.137", features = ["derive"] }
+tokio-stream = { version = "0.1.14", features = ["sync"] }
 thiserror = "1.0.31"
 itertools = "0.10.3"
 prost = { version = "0.11" }
@@ -35,7 +37,7 @@ ripemd = "0.1.3"
 digest = "0.10.6"
 quick_cache = "0.3.0"
 rand = "0.8.5"
-anchor-client = {version = "0.29.0", features = ["async"] }
+anchor-client = { version = "0.29.0", features = ["async"] }
 anchor-lang = "0.29.0"
 anchor-spl = "0.29.0"
 solana-transaction-status = "=1.17.31"
@@ -54,8 +56,14 @@ bs58 = { version = "0.5.0", features = ["alloc"] }
 bincode = { version = "1.3.3" }
 
 # New IBC
-ibc-new-primitives = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false, features = ["borsh", "serde"] , package="ibc-primitives" }
-ibc-core-host-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false, features = ["borsh", "serde"]}
+ibc-new-primitives = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false, features = [
+    "borsh",
+    "serde",
+], package = "ibc-primitives" }
+ibc-core-host-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false, features = [
+    "borsh",
+    "serde",
+] }
 ibc-core-handler-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
 ibc-core-client-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
 ibc-core-connection-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
@@ -63,41 +71,55 @@ ibc-core-channel-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be
 ibc-app-transfer-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
 ibc-core-commitment-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
 ibc-client-tendermint-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-client-wasm-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false}
+ibc-client-wasm-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
 # ibc-testkit = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-proto-new = { version = "0.41.0", default-features = false, package="ibc-proto" }
+ibc-proto-new = { version = "0.41.0", default-features = false, package = "ibc-proto" }
 
 ics23 = { version = "0.11.1" }
 
 
-
 # Old IBC
 ibc = { path = "../../ibc/modules", features = [] }
-ibc-proto = { path = "../../ibc/proto", package="ibc-proto" }
+ibc-proto = { path = "../../ibc/proto", package = "ibc-proto" }
 ibc-primitives = { path = "../../contracts/pallet-ibc/primitives" }
-ics07-tendermint = { path = "../../light-clients/ics07-tendermint", features = ["dummy"] }
+ics07-tendermint = { path = "../../light-clients/ics07-tendermint", features = [
+    "dummy",
+] }
 ics08-wasm = { path = "../../light-clients/ics08-wasm" }
 ibc-rpc = { path = "../../contracts/pallet-ibc/rpc" }
-pallet-ibc = { path = "../../contracts/pallet-ibc", features = ["testing"]}
+pallet-ibc = { path = "../../contracts/pallet-ibc", features = ["testing"] }
 
 # Trie
 lib = { git = "https://github.com/ComposableFi/emulated-light-client/" }
 memory = { git = "https://github.com/ComposableFi/emulated-light-client/" }
-sealable-trie = { git = "https://github.com/ComposableFi/emulated-light-client/" ,features = ["borsh"] }
+sealable-trie = { git = "https://github.com/ComposableFi/emulated-light-client/", features = [
+    "borsh",
+] }
 stdx = { git = "https://github.com/ComposableFi/emulated-light-client/" }
 solana-trie = { git = "https://github.com/ComposableFi/emulated-light-client/" }
-trie-ids = { git = "https://github.com/ComposableFi/emulated-light-client/" ,features = ["borsh"] }
+trie-ids = { git = "https://github.com/ComposableFi/emulated-light-client/", features = [
+    "borsh",
+] }
 cf-guest = { path = "../../light-clients/cf-guest", default-features = false }
-cf-guest-og = { git = "https://github.com/ComposableFi/emulated-light-client/" ,package = "cf-guest" }
-guestchain = { git = "https://github.com/ComposableFi/emulated-light-client/" ,default-features = false }
+cf-guest-og = { git = "https://github.com/ComposableFi/emulated-light-client/", package = "cf-guest" }
+guestchain = { git = "https://github.com/ComposableFi/emulated-light-client/", default-features = false }
 
-cf-solana = { path = "../../light-clients/cf-solana", default-features = false}
-cf-solana-og = { git = "https://github.com/ComposableFi/emulated-light-client/", package = "cf-solana", features = ["serde"] }
+cf-solana = { path = "../../light-clients/cf-solana", default-features = false }
+cf-solana-og = { git = "https://github.com/ComposableFi/emulated-light-client/", package = "cf-solana", features = [
+    "serde",
+] }
 
 #Contract
-solana-ibc = { git = "https://github.com/ComposableFi/emulated-light-client/" ,features = ["no-entrypoint"]}
-solana-write-account = { git = "https://github.com/ComposableFi/emulated-light-client/", features = ["library"] }
-solana-witnessed-trie = { git = "https://github.com/ComposableFi/emulated-light-client/", default-features = false, features = ["api"] }
+solana-ibc = { git = "https://github.com/ComposableFi/emulated-light-client/", features = [
+    "no-entrypoint",
+    "witness",
+] }
+solana-write-account = { git = "https://github.com/ComposableFi/emulated-light-client/", features = [
+    "library",
+] }
+solana-witnessed-trie = { git = "https://github.com/ComposableFi/emulated-light-client/", default-features = false, features = [
+    "api",
+] }
 solana-signature-verifier = { git = "https://github.com/ComposableFi/emulated-light-client/" }
 
 tracing = "0.1.36"
@@ -116,12 +138,10 @@ tendermint-light-client = { git = "https://github.com/informalsystems/tendermint
     "rpc-client",
     "secp256k1",
     "unstable",
-#    "testing"
+    #    "testing"
 ] }
 tendermint-light-client-verifier = { git = "https://github.com/informalsystems/tendermint-rs", rev = "4d81b67c28510db7d2d99ed62ebfa9fdf0e02141", default-features = false }
 tendermint-light-client-verifier_new = { git = "https://github.com/mina86/tendermint-rs", rev = "45fbd500d731effb95a98257630feb46f6c41d06", default-features = false, package = "tendermint-light-client-verifier" }
 
 [features]
-testing = [
-    "primitives/testing"
-]
+testing = ["primitives/testing"]

--- a/hyperspace/solana/src/client.rs
+++ b/hyperspace/solana/src/client.rs
@@ -213,10 +213,9 @@ impl SolanaClient {
 	}
 
 	pub fn get_witness_key(&self, trie_key: &Pubkey) -> Pubkey {
-		wittrie::api::find_witness_account(
-			&self.solana_ibc_program_id,
-			trie_key,
-		).unwrap().0
+		wittrie::api::find_witness_account(&self.solana_ibc_program_id, trie_key)
+			.unwrap()
+			.0
 	}
 
 	pub fn get_ibc_storage_key(&self) -> Pubkey {
@@ -372,7 +371,7 @@ impl SolanaClient {
 			channel_whitelist: Arc::new(Mutex::new(config.channel_whitelist.into_iter().collect())),
 			trie_db_path: config.trie_db_path,
 			transaction_sender,
-			is_transaction_processing: Arc::new(Mutex::new(false))
+			is_transaction_processing: Arc::new(Mutex::new(false)),
 		})
 	}
 

--- a/hyperspace/solana/src/lib.rs
+++ b/hyperspace/solana/src/lib.rs
@@ -5,6 +5,7 @@ use anchor_client::{
 	solana_client::{rpc_client::RpcClient, rpc_config::RpcSendTransactionConfig},
 	solana_sdk::{
 		compute_budget::ComputeBudgetInstruction,
+		feature_set::spl_token_v3_4_0,
 		instruction::Instruction,
 		system_instruction::transfer,
 		transaction::{Transaction, VersionedTransaction},
@@ -570,13 +571,14 @@ deserialize client state"
 	) -> Result<QueryConnectionResponse, Self::Error> {
 		use ibc_proto_new::Protobuf;
 		let chain_account = self.get_chain_storage().await;
-		let proof_height = if u64::from(chain_account.head().unwrap().block_height) == at.revision_height {
-			log::info!("Using existing proof height {}", at.revision_height);
-			at.revision_height
-		} else {
-			log::info!("Using incremented proof height {}", at.revision_height + 1);
-			at.revision_height
-		};
+		let proof_height =
+			if u64::from(chain_account.head().unwrap().block_height) == at.revision_height {
+				log::info!("Using existing proof height {}", at.revision_height);
+				at.revision_height
+			} else {
+				log::info!("Using incremented proof height {}", at.revision_height + 1);
+				at.revision_height
+			};
 		let (trie, at_height) = self.get_trie(proof_height, true).await;
 		let storage = self.get_ibc_storage().await;
 		let connection_idx = ConnectionIdx::try_from(


### PR DESCRIPTION
Mostly changed `rollup/lib.rs` and `rollup/client.rs`.

For `RollupClient` added RPC parameters to connect L1 - needed to request current token supply.

In `RollupClient.submit` added static `LAST_SUPPLY_UPDATE_TIME` (tried to add it in client, but `submit` takes immutable ref, so unable to update) and once a day update token supply.