### PR TITLE
Replace Anchor dependency with a smaller fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "4436e0292ab1bb631b42973c61205e704475fe8126af845c8d923c0996328127"
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -189,7 +189,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anchor-syn",
  "bs58 0.5.1",
@@ -201,7 +201,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -211,7 +211,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-error"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-event"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-program"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -242,7 +242,7 @@ dependencies = [
 [[package]]
 name = "anchor-client"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anchor-lang",
  "anyhow",
@@ -261,7 +261,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -271,10 +271,10 @@ dependencies = [
 [[package]]
 name = "anchor-derive-serde"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anchor-syn",
- "borsh-derive-internal 0.9.3",
+ "borsh-derive-internal 0.10.3",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-space"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -293,7 +293,7 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -305,7 +305,7 @@ dependencies = [
  "anchor-derive-serde",
  "anchor-derive-space",
  "arrayref",
- "base64 0.21.7",
+ "base64 0.13.1",
  "bincode",
  "borsh 0.10.4",
  "bytemuck",
@@ -331,7 +331,7 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.29.0"
-source = "git+https://github.com/dhruvja/anchor#90a3008fcbbc5bcbc704cd6cccf61ef130c5f9eb"
+source = "git+https://github.com/mina86/anchor?branch=send-sync#db3660c5627a9c4449e9f331c3c3e523992a1178"
 dependencies = [
  "anyhow",
  "bs58 0.5.1",
@@ -1276,7 +1276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.11.2",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -5257,7 +5257,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.14",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -8394,7 +8394,7 @@ version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba8ee05284d79b367ae8966d558e1a305a781fc80c9df51f37775169117ba64f"
 dependencies = [
- "borsh 0.9.3",
+ "borsh 0.10.4",
  "num-derive 0.3.3",
  "num-traits",
  "solana-program",
@@ -12229,7 +12229,7 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -12276,7 +12276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.61",
@@ -15139,7 +15139,7 @@ dependencies = [
  "bytes",
  "ics23 0.10.0",
  "proptest",
- "rand 0.8.5",
+ "rand 0.4.6",
  "sha2 0.10.8",
  "tendermint 0.33.2",
 ]
@@ -18984,7 +18984,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 0.1.10",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ jsonrpsee = { version = "0.16.3" }
 aes-gcm-siv = { git = "https://github.com/RustCrypto/AEADs", rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef" }
 curve25519-dalek-new = { git = "https://github.com/dalek-cryptography/curve25519-dalek", rev = "0cd099a9fb8ff9f6fedc8723d44dbb1c743e9d35", package = "curve25519-dalek" }
 curve25519-dalek = { git = "https://github.com/solana-labs/curve25519-dalek.git", rev = "b500cdc2a920cd5bff9e2dd974d7b97349d61464" }
-anchor-client = { git = "https://github.com/dhruvja/anchor" }
-anchor-lang = { git = "https://github.com/dhruvja/anchor" }
+anchor-client = { git = "https://github.com/mina86/anchor", branch = "send-sync" }
+anchor-lang = { git = "https://github.com/mina86/anchor", branch = "send-sync" }
 
 ibc                         = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false, features = ["borsh", "serde"] }
 ibc-client-tendermint-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }


### PR DESCRIPTION
Replace Anchor dependency with a fork which diverges less from 0.29.
The previous one had 30 commits on top of v0.29.0 tag (with 29 pulled
from Anchor master).  The new one is v0.29.0 with just a single commit
that we need on top of it.

Somehow this addresses the following build errors:

    error[E0046]: not all trait items implemented, missing: `deserialize_reader`
      --> /home/mpn/.cargo/git/checkouts/anchor-714801cc5351d5e5/90a3008/lang/src/idl.rs:35:27
       |
    35 | #[derive(AnchorSerialize, AnchorDeserialize)]
       |                           ^^^^^^^^^^^^^^^^^ missing `deserialize_reader` in implementation

    error[E0046]: not all trait items implemented, missing: `deserialize_reader`
      --> /home/mpn/.cargo/git/checkouts/anchor-714801cc5351d5e5/90a3008/lang/src/idl.rs:62:1
       |
    62 | #[account("internal")]
       | ^^^^^^^^^^^^^^^^^^^^^^ missing `deserialize_reader` in implementation
